### PR TITLE
fix: log documentation URL in case of an error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ export async function oauthRequest(
 
   if ("error" in response.data) {
     const error = new RequestError(
-      `${response.data.error_description} (${response.data.error}, ${response.data.error_url})`,
+      `${response.data.error_description} (${response.data.error}, ${response.data.error_uri})`,
       400,
       {
         request: request.endpoint.merge(

--- a/test/exchange-device-code.test.ts
+++ b/test/exchange-device-code.test.ts
@@ -119,7 +119,7 @@ describe("exchangeDeviceCode()", () => {
       {
         error: "authorization_pending",
         error_description: "error_description",
-        error_url: "error_url",
+        error_uri: "error_uri",
       },
       {
         headers: {
@@ -151,7 +151,7 @@ describe("exchangeDeviceCode()", () => {
           }),
         })
     ).rejects.toMatchInlineSnapshot(
-      `[HttpError: error_description (authorization_pending, error_url)]`
+      `[HttpError: error_description (authorization_pending, error_uri)]`
     );
   });
 


### PR DESCRIPTION
I noticed in both my personal testing and in the docs that this is supposed to be `error_uri`: https://docs.github.com/en/developers/apps/troubleshooting-oauth-app-access-token-request-errors