### PR TITLE
Updates fetch-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^29.0.0",
         "@types/node": "^18.0.0",
         "esbuild": "^0.19.0",
-        "fetch-mock": "^9.11.0",
+        "fetch-mock": "npm:@gr2m/fetch-mock@9.11.0-pull-request-644.1",
         "glob": "^10.2.7",
         "jest": "^29.0.0",
         "prettier": "3.0.3",
@@ -3956,9 +3956,10 @@
       }
     },
     "node_modules/fetch-mock": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
-      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "name": "@gr2m/fetch-mock",
+      "version": "9.11.0-pull-request-644.1",
+      "resolved": "https://registry.npmjs.org/@gr2m/fetch-mock/-/fetch-mock-9.11.0-pull-request-644.1.tgz",
+      "integrity": "sha512-gTp6RCHzlOXS1qRb0APfuyz48Lw/JFPa4uiar+kEgL1STsDwth75HJZ4x30tBlXMJXV8XDTDzJ2Hz9w3RWiHJA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/jest": "^29.0.0",
     "@types/node": "^18.0.0",
     "esbuild": "^0.19.0",
-    "fetch-mock": "^9.11.0",
+    "fetch-mock": "npm:@gr2m/fetch-mock@9.11.0-pull-request-644.1",
     "glob": "^10.2.7",
     "jest": "^29.0.0",
     "prettier": "3.0.3",


### PR DESCRIPTION
This PR updates fetch-mock to use the branched version that implements fetch globally. 

todo: test failures due to issues with snapshots