### PR TITLE
fix(utils): correctly translate api.*.ghe.com URLs to base URLs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,13 @@ import { RequestError } from "@octokit/request-error";
 
 export function requestToOAuthBaseUrl(request: RequestInterface): string {
   const endpointDefaults = request.endpoint.DEFAULTS;
-  return /^https:\/\/(api\.)?github\.com$/.test(endpointDefaults.baseUrl)
-    ? "https://github.com"
-    : endpointDefaults.baseUrl.replace("/api/v3", "");
+  if (/^https:\/\/(api\.)?github\.com$/.test(endpointDefaults.baseUrl)) {
+    return "https://github.com";
+  }
+  if (/^https:\/\/api\..*\.ghe\.com$/.test(endpointDefaults.baseUrl)) {
+    return endpointDefaults.baseUrl.replace("api.", "");
+  }
+  return endpointDefaults.baseUrl.replace("/api/v3", "");
 }
 
 export async function oauthRequest(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { requestToOAuthBaseUrl } from "../src/utils";
+import { request } from "@octokit/request";
+
+describe("requestToOAuthBaseUrl()", () => {
+  it("api.github.com example", async () => {
+    const req = request.defaults({ baseUrl: "https://api.github.com" });
+    const oauthUrl = requestToOAuthBaseUrl(req);
+    expect(oauthUrl).toBe("https://github.com");
+  });
+
+  it("github.com example", async () => {
+    const req = request.defaults({ baseUrl: "https://github.com" });
+    const oauthUrl = requestToOAuthBaseUrl(req);
+    expect(oauthUrl).toBe("https://github.com");
+  });
+
+  it("GHEC API example", async () => {
+    const req = request.defaults({ baseUrl: "https://api.apiexample.ghe.com" });
+    const oauthUrl = requestToOAuthBaseUrl(req);
+    expect(oauthUrl).toBe("https://apiexample.ghe.com");
+  });
+
+  it("GHEC example", async () => {
+    const req = request.defaults({ baseUrl: "https://apiexample.ghe.com" });
+    const oauthUrl = requestToOAuthBaseUrl(req);
+    expect(oauthUrl).toBe("https://apiexample.ghe.com");
+  });
+
+  it("GHES API example", async () => {
+    const req = request.defaults({ baseUrl: "https://example.com/api/v3" });
+    const oauthUrl = requestToOAuthBaseUrl(req);
+    expect(oauthUrl).toBe("https://example.com");
+  });
+
+  it("GHES example", async () => {
+    const req = request.defaults({ baseUrl: "https://example.com" });
+    const oauthUrl = requestToOAuthBaseUrl(req);
+    expect(oauthUrl).toBe("https://example.com");
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #357 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* [GHEC with data residency](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency/about-github-enterprise-cloud-with-data-residency) API URLs of the form `https://api.*.ghe.com` were passed through without modification by `requestToOAuthBaseUrl` .
* Functions using the above (`refreshToken`, `createDeviceCode`, `exchangeWebFlowCode`, `exchangeDeviceCode`) would unexpectedly fail with a 404 `RequestError`.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `requestToOAuthBaseUrl` maps `https://api.*.ghe.com` to `https://*.ghe.com` instead.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

